### PR TITLE
Fix DIGITS token so it does not accept leading 0

### DIFF
--- a/jbossply/jbossparser.py
+++ b/jbossply/jbossparser.py
@@ -118,7 +118,7 @@ class JbossLexer(object):
     t_NULL = r'\x6e\x75\x6c\x6c'  # 'null'
     t_UNDEFINED = r'undefined'  # 'null'
     t_DECIMAL_POINT = r'\x2E'  # '.'
-    t_DIGITS = r'[\x30-\x39]+'  # '0'..'9'
+    t_DIGITS = r'[\x31-\x39][\x30-\x39]*'  # ['1'-'9']['0'-'9']*
     t_E = r'[\x45\x65]'  # 'e' or 'E'
     t_MINUS = r'\x2D'  # '-'
     t_PLUS = r'\x2B'  # '+'


### PR DESCRIPTION
Trying to parse the following output of `read-resource(attributes-only=true)` lead to `null` being returned.

```
{
    "outcome" => "success",
    "result" => {
        "management-major-version" => 1,
        "management-micro-version" => 0,
        "management-minor-version" => 7,
        "name" => "Unnamed Domain",
        "namespaces" => [],
        "product-name" => "EAP",
        "product-version" => "6.4.0.GA",
        "release-codename" => "Janus",
        "release-version" => "7.5.0.Final-redhat-21",
        "schema-locations" => []
    }
}
```

Problem seems to be that the `0` for the `management-micro-version` was being tokenized as a `DIGITS`, as opposed to a `ZERO`.

I changed the `DIGITS` token to not accept a leading 0, and that allowed me to parse the output correctly.